### PR TITLE
Delete unused imports

### DIFF
--- a/signal_generator.py
+++ b/signal_generator.py
@@ -1,4 +1,4 @@
-from math import pi, sin, lcm
+from math import pi, sin
 import matplotlib.pyplot as plt
 from audio import Audio
 from convert_to_pcm import convert_to_pcm


### PR DESCRIPTION
Python 3.8 이하에서 지원되지도 않고 사용하지 않은 import 제거